### PR TITLE
fix order of list to sort it for test

### DIFF
--- a/lib/http_proxy/play/data.ex
+++ b/lib/http_proxy/play/data.ex
@@ -14,22 +14,28 @@ defmodule HttpProxy.Play.Data do
 
   ## Example
 
-      iex> HttpProxy.Play.Data.responses
-      ["get_8080/request/path": %{"request" => %{"method" => "GET",
+      iex> HttpProxy.Play.Data.responses[:"get_8080/request/path"]
+      %{"request" => %{"method" => "GET",
            "path" => "/request/path", "port" => 8080},
          "response" => %{"body" => "<html>hello world</html>", "cookies" => %{},
            "headers" => %{"Content-Type" => "text/html; charset=UTF-8",
-             "Server" => "GFE/2.0"}, "status_code" => 200}},
-       "get_8080\\A/request.*neko\\z": %{"request" => %{"method" => "GET",
+             "Server" => "GFE/2.0"}, "status_code" => 200}}
+
+      iex> HttpProxy.Play.Data.responses[:"get_8080\\A/request.*neko\\z"]
+      %{"request" => %{"method" => "GET",
            "path_pattern" => "\\A/request.*neko\\z", "port" => 8080},
          "response" => %{"body_file" => "test/data/__files/example.json", "cookies" => %{},
            "headers" => %{"Content-Type" => "text/html; charset=UTF-8",
-             "Server" => "GFE/2.0"}, "status_code" => 200}},
-       "post_8081/request/path": %{"request" => %{"method" => "POST",
+             "Server" => "GFE/2.0"}, "status_code" => 200}}
+
+      iex> HttpProxy.Play.Data.responses[:"post_8081/request/path"]
+      %{"request" => %{"method" => "POST",
            "path" => "/request/path", "port" => 8081},
          "response" => %{"body" => "<html>hello world 3</html>", "cookies" => %{},
            "headers" => %{"Content-Type" => "text/html; charset=UTF-8",
-             "Server" => "GFE/2.0"}, "status_code" => 201}}]
+             "Server" => "GFE/2.0"}, "status_code" => 201}}
+
+
   """
   @spec responses() :: binary
   def responses, do: response ProxyAgent.get(@responses)

--- a/lib/http_proxy/utils/file.ex
+++ b/lib/http_proxy/utils/file.ex
@@ -139,11 +139,12 @@ defmodule HttpProxy.Utils.File do
 
   ## Example
 
-      iex> HttpProxy.Utils.File.json_files!("test/data/mappings")
+      iex> HttpProxy.Utils.File.json_files!("test/data/mappings") |> Enum.sort
       ["test/data/mappings/sample.json", "test/data/mappings/sample2.json", "test/data/mappings/sample3.json"]
 
-      iex> HttpProxy.Utils.File.json_files("test/data/mappings")
-      {:ok, ["test/data/mappings/sample.json", "test/data/mappings/sample2.json", "test/data/mappings/sample3.json"]}
+      iex> {:ok, paths} = HttpProxy.Utils.File.json_files("test/data/mappings")
+      iex> paths |> Enum.sort
+      ["test/data/mappings/sample.json", "test/data/mappings/sample2.json", "test/data/mappings/sample3.json"]
   """
   @spec json_files(String.t) :: binary
   def json_files!(dir) do

--- a/test/http_proxy/http_test.exs
+++ b/test/http_proxy/http_test.exs
@@ -115,7 +115,9 @@ defmodule HttpProxy.HttpTest do
                 "response" => %{"body" => "<html>hello world 3</html>", "cookies" => %{},
                   "headers" => %{"Content-Type" => "text/html; charset=UTF-8", "Server" => "GFE/2.0"}, "status_code" => 201}}]
 
-      assert Response.play_responses == expected
+      assert Response.play_responses[:"get_8080/request/path"] == expected[:"get_8080/request/path"]
+      assert Response.play_responses[:"get_8080\\A/request.*neko\\z"] == expected[:"get_8080\\A/request.*neko\\z"]
+      assert Response.play_responses[:"post_8081/request/path"] == expected[:"post_8081/request/path"]
     end
 
     should "HttpProxy.Play.Response#play_responses with record mode" do

--- a/test/http_proxy/utils/file_test.exs
+++ b/test/http_proxy/utils/file_test.exs
@@ -14,8 +14,8 @@ defmodule HttpProxy.Utils.FileTest do
               "response" => %{"body" => "<html>hello world</html>", "cookies" => %{},
                 "headers" => %{"Content-Type" => "text/html; charset=UTF-8", "Server" => "GFE/2.0"}, "status_code" => 200}}
 
-    assert {:ok, json_file_path} == HttpProxyFile.json_files(json_test_dir)
-    assert {:ok, expected_json} == HttpProxyFile.read_json_file(List.first(json_file_path))
+    assert json_file_path == HttpProxyFile.json_files!(json_test_dir) |> Enum.sort
+    assert {:ok, expected_json} == HttpProxyFile.read_json_file("test/data/mappings/sample.json")
   end
 
   test "failed to read json files" do


### PR DESCRIPTION
ref: 5 tests are failing #26 

Tests failed because order of list, get via `HttpProxyFile.json_files`, depends on environment of machines, I guess.
So, I arranged failed tests not to depend on the order.